### PR TITLE
Allow comma separated list compaction for skip argument

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: kubeconform
-version: 0.1.12
+version: 0.1.13
 usage: Kubernetes manifest validation tool for Helm charts
 description: Kubernetes manifest validation tool for Helm charts
 ignoreFlags: false

--- a/scripts/plugin_wrapper.py
+++ b/scripts/plugin_wrapper.py
@@ -346,9 +346,12 @@ def parse_config(filename):
     if isinstance(data, dict):
         for key, val in data.items():
             if isinstance(val, list):
-                for v in val:
-                    args.append("-%s=%s" % (key, v))
-            elif isinstance(v, dict):
+                if key == "skip":
+                    args.append("-%s=%s" % (key, ",".join(val)))
+                else:
+                    for v in val:
+                        args.append("-%s=%s" % (key, v))
+            elif isinstance(val, dict):
                 # No deep dicts allowed in the config
                 continue
             else:


### PR DESCRIPTION
At the moment helm plugin doesn't allow setting multiple entries for the `skip` option. That is because, kubeconform `-skip` command line argument, unlike `schema-location`, doesn't support repeated entries on the CLI:
```
$ kubeconform --help
Usage: kubeconform [OPTION]... [FILE OR FOLDER]...
...
  -schema-location value
    	override schemas location search path (can be specified multiple times)
  -skip string
    	comma-separated list of kinds or GVKs to ignore
...
```

This PR addresses the above issue and allows for following configuration:
```
skip:
  - monitoring.grafana.com/v1alpha1/GrafanaAgent
  - monitoring.grafana.com/v1alpha1/PodLogs
  - monitoring.grafana.com/v1alpha1/LogsInstance
  - monitoring.grafana.com/v1alpha1/MetricsInstance
```
