### PR TITLE
Add a `--kube-version` option to pass to `helm template`

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: kubeconform
-version: 0.1.15
+version: 0.1.16
 usage: Kubernetes manifest validation tool for Helm charts
 description: Kubernetes manifest validation tool for Helm charts
 ignoreFlags: false

--- a/scripts/plugin_wrapper.py
+++ b/scripts/plugin_wrapper.py
@@ -144,7 +144,7 @@ def parse_args(
         "-v",
         "--kube-version",
         metavar="VERSION",
-        help="Kubernetes version to generate for",
+        help="Kubernetes version to generate for (default: same as --kubernetes-version)",
     )
 
     group_helm_tmpl.add_argument(
@@ -257,6 +257,9 @@ def parse_args(
         args["helm_build"] += [a.CHART]
 
     # ### Populate the helm template options
+    if a.kube_version is None and a.kubernetes_version is not None:
+        a.kube_version = a.kubernetes_version
+
     if a.kube_version is not None:
         args["helm_tmpl"] += ["--kube-version", a.kube_version]
 

--- a/scripts/plugin_wrapper.py
+++ b/scripts/plugin_wrapper.py
@@ -141,6 +141,13 @@ def parse_args(
     )
 
     group_helm_tmpl.add_argument(
+        "-v",
+        "--kube-version",
+        metavar="VERSION",
+        help="Kubernetes version to generate for",
+    )
+
+    group_helm_tmpl.add_argument(
         "-f",
         "--values",
         metavar="FILE",
@@ -250,6 +257,9 @@ def parse_args(
         args["helm_build"] += [a.CHART]
 
     # ### Populate the helm template options
+    if a.kube_version is not None:
+        args["helm_tmpl"] += ["--kube-version", a.kube_version]
+
     if a.values:
         for v in a.values:
             args["helm_tmpl"] += ["--values", v]


### PR DESCRIPTION
Currently, templates are only generated with the current Kubernetes version, but it is possible to validate against any schema. This means that it's not actually possible to generate what you intend to validate. This commit adds `--kube-version` option, which gets passed down to `helm template`. The option default is whatever `--kubernetes-version` is set to, if set.

This option is deliberately separate from `--kubernetes-version` because a) they are passed to two different commands and b) there may be reasons why a user might want to validate against a schema that doesn't match what the template was generated for, such as to validate cross-version compatibility.