### PR TITLE
fix: -skip parameter not properly used

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: kubeconform
-version: 0.1.16
+version: 0.1.17
 usage: Kubernetes manifest validation tool for Helm charts
 description: Kubernetes manifest validation tool for Helm charts
 ignoreFlags: false

--- a/scripts/plugin_wrapper.py
+++ b/scripts/plugin_wrapper.py
@@ -303,8 +303,8 @@ def parse_args(
         for v in a.schema_location:
             args["kubeconform"] += ["-schema-location", v]
 
-    if a.skip is True:
-        args["kubeconform"] += ["-skip"]
+    if a.skip is not None:
+        args["kubeconform"] += ["-skip", a.skip]
 
     if a.strict is True:
         args["kubeconform"] += ["-strict"]


### PR DESCRIPTION
The `-skip` should pass a comma separated list of Kinds to be skipped. 

The parameter was passing nothing, and so was not used. 

Tested with 
`helm kubeconform mychart --skip "Middleware"` 

Before this fix, the same command returned : 
```
$ helm kubeconform mychart  --skip "Middleware"
ERROR: Testing failed: kubeconform failed: failed to run kubeconform: rc=1
stdin - Middleware whitelist-kubeconform-main is invalid: problem validating schema. Check JSON formatting: jsonschema: '/spec' does not validate with https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/traefik.io/middleware_v1alpha1.json#/properties/spec/additionalProperties: additionalProperties 'ipAllowList' not allowed
Error: plugin "kubeconform" exited with error
```