### PR TITLE
binloader: mitigate rate limiting: pass GITHUB_TOKEN

### DIFF
--- a/scripts/plugin_binloader.sh
+++ b/scripts/plugin_binloader.sh
@@ -100,15 +100,23 @@ getDownloadURLs() {
   # Use the GitHub API to find the latest version for this project.
   latest_url="https://api.github.com/repos/$PROJECT_GH/releases/latest"
 
-  echo "Retrieving $latest_url"
-
-  if [ $DOWNLOADER = 'curl' ]; then
-    DOWNLOAD_URL=$(curl -sL "$latest_url" | grep "$OS-$ARCH" | awk '/"browser_download_url":/{gsub(/[,"]/,"", $2); print $2}' 2>/dev/null)
-    PROJECT_CHECKSUM=$(curl -sL "$latest_url" | grep "$PROJECT_CHECKSUM_FILE" | awk '/"browser_download_url":/{gsub(/[,"]/,"", $2); print $2}' 2>/dev/null)
-  elif [ $DOWNLOADER = 'wget' ]; then
-    DOWNLOAD_URL=$(wget -q -O - "$latest_url" | grep "$OS-$ARCH" | awk '/"browser_download_url":/{gsub(/[,"]/,"", $2); print $2}' 2>/dev/null)
-    PROJECT_CHECKSUM=$(wget -q -O - "$latest_url" | grep "$PROJECT_CHECKSUM_FILE" | awk '/"browser_download_url":/{gsub(/[,"]/,"", $2); print $2}' 2>/dev/null)
+  # Mitigate API Rate Limiting
+  if [ -n "${GITHUB_TOKEN}" ]; then
+    auth_header="Authorization: Bearer ${GITHUB_TOKEN}"
   fi
+
+  echo "Retrieving $latest_url ${auth_header:+"with token"}"
+
+  if [ "$DOWNLOADER" = 'curl' ]; then
+    response=$(curl -sL ${auth_header:+"-H$auth_header"} "$latest_url")
+  elif [ "$DOWNLOADER" = 'wget' ]; then
+    response=$(wget -q ${auth_header:+"--header=$auth_header"} -O - "$latest_url" || true)
+  fi
+  unset auth_header
+
+  DOWNLOAD_URL=$(echo "$response" | grep "$OS-$ARCH" | awk '/"browser_download_url":/{gsub(/[,"]/,"", $2); print $2}')
+  PROJECT_CHECKSUM=$(echo "$response" | grep "$PROJECT_CHECKSUM_FILE" | awk '/"browser_download_url":/{gsub(/[,"]/,"", $2); print $2}')
+  unset response
 
   if [ -z "$DOWNLOAD_URL" ]; then
     echo 'Failed to get DOWNLOAD_URL'


### PR DESCRIPTION
Similarly to #29 , this is a proposed implementation to permit mitigating Github API rate limiting issues.
This would do so by : 
- **passing** `GITHUB_TOKEN` env var as a header to the API for authorization
- **halving** the API calls used to get the Download & Checksum URLs

---

➡️ **My major concern is avoiding being rate limited in our CI pipelines _as soon as possible_.** ⏳ 
As such, if merging #29 is preferred to the current one, please proceed and we'll shred this one.

---

Since the script appears to target high compatibility ( posix shell -> no bashisms ? ) : 
- arrays not available -> using var expansion syntax to avoid passing empty ( "" ) arguments to curl
- curl is not accepting `--header=A: B` syntax ( it dislikes the `=` )
- _if I missed anything, please do let me know and I will adapt it accordingly_ 🙏 