### PR TITLE
feat: support Helm charts in repo root (--charts-path=.)

### DIFF
--- a/scripts/pre_commit.py
+++ b/scripts/pre_commit.py
@@ -60,6 +60,20 @@ def main():
 
     for i, charts_path in enumerate(args["wrapper"].charts_path):
         for f in args["wrapper"].FILES:
+            # Support chart in repo root when charts_path is "." or ""
+            if charts_path in (".", ""):
+                if not f.startswith(".."):
+                    path = "."
+                    name = "chart"
+                    if (
+                        include_charts and name not in include_charts
+                    ) or name in exclude_charts:
+                        continue
+                    if path not in charts:
+                        charts[name] = path
+                    continue
+                continue
+
             if f.startswith("%s%s" % (charts_path, os.sep)):
                 # Path substitution if any is defined
                 if (


### PR DESCRIPTION
When using the pre-commit hook with `--charts-path=.`, the chart is located in the repository root rather than in a subdirectory. The current logic fails to discover such charts because it only looks for `Chart.yaml` inside subdirectories of the charts path.

This change adds handling for the case when the charts path itself is a chart (contains `Chart.yaml` at the top level), enabling `--charts-path=.` to work correctly in pre-commit hooks.

**Changes:**
- `scripts/pre_commit.py`: added a check for `Chart.yaml` in the charts path root before searching subdirectories.