### PR TITLE
feat: add --skip-dep-build flag to skip helm dependency build/update

### DIFF
--- a/scripts/plugin_wrapper.py
+++ b/scripts/plugin_wrapper.py
@@ -125,6 +125,11 @@ def parse_args(
     )
 
     group_helm_build.add_argument(
+        "--skip-dep-build",
+        help="skip helm dependency build/update",
+        action="store_true",
+    )
+    group_helm_build.add_argument(
         "--skip-refresh",
         help="do not refresh the local repository cache",
         action="store_true",
@@ -563,12 +568,13 @@ def run_test(args, values_file=None):
         ]
 
     # Build Helm dependencies
-    try:
-        run_helm_dependecy_build(
-            args["helm_build"],
-        )
-    except Exception as e:
-        raise Exception("dependency build failed: %s" % e)
+    if not args["wrapper"].skip_dep_build:
+        try:
+            run_helm_dependecy_build(
+                args["helm_build"],
+            )
+        except Exception as e:
+            raise Exception("dependency build failed: %s" % e)
 
     # Get templated output
     try:


### PR DESCRIPTION
Adds a `--skip-dep-build` flag that allows skipping `helm dependency build/update` before running `helm template`.

**Motivation:**
When chart dependencies are already vendored in the `charts/` directory (committed to the repository), running `helm dependency update` on every validation is unnecessary and can cause unwanted side effects:
- Updates `Chart.lock` with newer dependency versions
- Downloads new chart tarballs into `charts/`
- Creates dirty git state during pre-commit hooks

The `--skip-dep-build` flag solves this by skipping the dependency resolution step entirely.

**Changes:**
- `scripts/plugin_wrapper.py`: added `--skip-dep-build` argument to the `helm build` argument group and wrapped the `run_helm_dependecy_build()` call in `run_test()` with a conditional check.

**Usage:**
```bash
helm kubeconform --skip-dep-build --kubernetes-version 1.33.0 .
```

In `.pre-commit-config.yaml`:
```yaml
- repo: https://github.com/jtyr/kubeconform-helm
  rev: v0.2.0
  hooks:
    - id: kubeconform-helm
      args:
        - --skip-dep-build
        - --kubernetes-version=1.33.0
```